### PR TITLE
fix: cross-file import resolution for all checker rules

### DIFF
--- a/examples/worker/src/main.roca
+++ b/examples/worker/src/main.roca
@@ -24,12 +24,6 @@ pub fn handle(kv: KV, fetcher: Fetcher, logger: Logger, method: String, path: St
 
     return not_found()
 
-    crash {
-        get_user -> halt
-        create_user -> halt
-        delete_user -> halt
-    }
-
     test {
         self(__mock_KV, __mock_Fetcher, __mock_Logger, "GET", "/users/1", "") is Ok
         self(__mock_KV, __mock_Fetcher, __mock_Logger, "GET", "/nope", "") is Ok

--- a/src/check/context.rs
+++ b/src/check/context.rs
@@ -19,6 +19,8 @@ pub struct FnContext<'a> {
 pub struct CheckContext<'a> {
     pub file: &'a SourceFile,
     pub registry: &'a ContractRegistry,
+    /// Directory the source file lives in — used for resolving relative imports
+    pub source_dir: Option<std::path::PathBuf>,
 }
 
 /// Context at item level

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -36,7 +36,11 @@ pub fn check(file: &SourceFile) -> Vec<RuleError> {
 }
 
 pub fn check_with_registry(file: &SourceFile, registry: &ContractRegistry) -> Vec<RuleError> {
-    walker::walk(file, registry, &all_rules())
+    walker::walk(file, registry, None, &all_rules())
+}
+
+pub fn check_with_registry_and_dir(file: &SourceFile, registry: &ContractRegistry, source_dir: Option<&std::path::Path>) -> Vec<RuleError> {
+    walker::walk(file, registry, source_dir, &all_rules())
 }
 
 #[cfg(test)]

--- a/src/check/registry.rs
+++ b/src/check/registry.rs
@@ -236,7 +236,7 @@ impl ContractRegistry {
     /// e.g. "Email.validate" → check Email struct's validate method
     /// e.g. "intl.dateTime" → resolve intl from params to DateFormatting, check dateTime
     /// Returns None if unknown (can't resolve), Some(true/false) if known.
-    pub fn call_returns_err_with_scope(&self, call_name: &str, file: &SourceFile, scope: &std::collections::HashMap<String, String>) -> Option<bool> {
+    pub fn call_returns_err_with_scope(&self, call_name: &str, file: &SourceFile, scope: &std::collections::HashMap<String, String>, source_dir: Option<&std::path::Path>) -> Option<bool> {
         if let Some(dot) = call_name.find('.') {
             let var_name = &call_name[..dot];
             let method_name = &call_name[dot + 1..];
@@ -262,7 +262,7 @@ impl ContractRegistry {
                 return Some(returns_err);
             }
         } else {
-            // Top-level function name
+            // Top-level function name — check current file
             for item in &file.items {
                 if let Item::Function(f) = item {
                     if f.name == call_name {
@@ -274,6 +274,10 @@ impl ContractRegistry {
                         return Some(f.returns_err);
                     }
                 }
+            }
+            // Check imported functions
+            if let Some(resolved) = crate::resolve::find_imported_fn(call_name, file, source_dir) {
+                return Some(resolved.returns_err);
             }
         }
         None

--- a/src/check/rules/contracts.rs
+++ b/src/check/rules/contracts.rs
@@ -55,7 +55,7 @@ mod tests {
         let file = crate::parse::parse(src);
         let reg = ContractRegistry::build(&file);
         let rule = ContractsRule;
-        let ctx = CheckContext { file: &file, registry: &reg };
+        let ctx = CheckContext { file: &file, registry: &reg, source_dir: None };
         file.items.iter().flat_map(|item| {
             rule.check_item(&ItemContext { check: &ctx, item })
         }).collect()

--- a/src/check/rules/crash.rs
+++ b/src/check/rules/crash.rs
@@ -220,31 +220,35 @@ impl Rule for CrashRule {
 
         // Only calls to error-returning functions need crash entries
         let err_calls: Vec<&String> = calls.iter()
-            .filter(|c| ctx.check.registry.call_returns_err_with_scope(c, ctx.check.file, &scope) == Some(true))
+            .filter(|c| ctx.check.registry.call_returns_err_with_scope(c, ctx.check.file, &scope, ctx.check.source_dir.as_deref()) == Some(true))
             .collect();
 
-        if err_calls.is_empty() { return errors; }
-
-        let crash = match &f.crash {
-            Some(c) => c,
-            None => {
-                for call in &err_calls {
-                    errors.push(RuleError::new(errors::MISSING_CRASH, format!("'{}' returns errors but has no crash handler in '{}'", call, f.name), Some(ctx.func.qualified_name.clone())));
+        if !err_calls.is_empty() {
+            let crash = match &f.crash {
+                Some(c) => c,
+                None => {
+                    for call in &err_calls {
+                        errors.push(RuleError::new(errors::MISSING_CRASH, format!("'{}' returns errors but has no crash handler in '{}'", call, f.name), Some(ctx.func.qualified_name.clone())));
+                    }
+                    return errors;
                 }
-                return errors;
-            }
-        };
+            };
 
-        let handled: Vec<&str> = crash.handlers.iter().map(|h| h.call.as_str()).collect();
-        for call in &err_calls {
-            if !handled.iter().any(|h| *h == call.as_str()) {
-                errors.push(RuleError::new(errors::UNHANDLED_CALL, format!("'{}' returns errors but has no crash handler in '{}'", call, f.name), Some(ctx.func.qualified_name.clone())));
+            let handled: Vec<&str> = crash.handlers.iter().map(|h| h.call.as_str()).collect();
+            for call in &err_calls {
+                if !handled.iter().any(|h| *h == call.as_str()) {
+                    errors.push(RuleError::new(errors::UNHANDLED_CALL, format!("'{}' returns errors but has no crash handler in '{}'", call, f.name), Some(ctx.func.qualified_name.clone())));
+                }
             }
         }
 
         // Check each crash handler for misuse: crash-on-safe and panic warnings
+        let crash = match &f.crash {
+            Some(c) => c,
+            None => return errors,
+        };
         for handler in &crash.handlers {
-            let returns_err = ctx.check.registry.call_returns_err_with_scope(&handler.call, ctx.check.file, &scope);
+            let returns_err = ctx.check.registry.call_returns_err_with_scope(&handler.call, ctx.check.file, &scope, ctx.check.source_dir.as_deref());
 
             // Crash entries with halt/fallback/retry on non-error functions are invalid —
             // these strategies destructure {value, err} but non-error functions return plain values

--- a/src/check/rules/tests.rs
+++ b/src/check/rules/tests.rs
@@ -191,7 +191,7 @@ impl Rule for TestsRule {
         };
 
         check_test_coverage(f, declared_errors, &ctx.func.qualified_name, &mut errors);
-        check_mock_refs(f, ctx.check.file, &ctx.func.qualified_name, &mut errors);
+        check_mock_refs(f, ctx.check.file, ctx.check.source_dir.as_deref(), &ctx.func.qualified_name, &mut errors);
         errors
     }
 }
@@ -231,7 +231,7 @@ fn check_test_coverage(f: &FnDef, declared_errors: &[ErrDecl], qn: &str, errors:
     }
 }
 
-fn check_mock_refs(f: &FnDef, file: &SourceFile, qn: &str, errors: &mut Vec<RuleError>) {
+fn check_mock_refs(f: &FnDef, file: &SourceFile, source_dir: Option<&std::path::Path>, qn: &str, errors: &mut Vec<RuleError>) {
     let test = match &f.test {
         Some(t) => t,
         None => return,
@@ -249,7 +249,7 @@ fn check_mock_refs(f: &FnDef, file: &SourceFile, qn: &str, errors: &mut Vec<Rule
     for item in &file.items {
         if let Item::Import(imp) = item {
             if let ImportSource::Path(path) = &imp.source {
-                if let Some(imported) = crate::resolve::try_load_roca_file(path) {
+                if let Some(imported) = crate::resolve::try_load_roca_file_from(path, source_dir) {
                     for imp_item in &imported.items {
                         match imp_item {
                             Item::Contract(c) if c.mock.is_some() => { valid_mocks.insert(c.name.clone()); }

--- a/src/check/rules/types.rs
+++ b/src/check/rules/types.rs
@@ -137,13 +137,21 @@ impl Rule for TypeCheckRule {
             // Function call: check arg types match param types
             Expr::Call { target, args } => {
                 if let Expr::Ident(fn_name) = target.as_ref() {
-                    // Look up the function in the file
+                    // Look up the function in the current file
+                    let mut found = false;
                     for item in &ctx.check.file.items {
                         if let Item::Function(f) = item {
                             if f.name == *fn_name {
                                 check_call_args(fn_name, &f.params, args, ctx, &mut errors);
+                                found = true;
                                 break;
                             }
+                        }
+                    }
+                    // Check imported functions
+                    if !found {
+                        if let Some(resolved) = crate::resolve::find_imported_fn(fn_name, ctx.check.file, ctx.check.source_dir.as_deref()) {
+                            check_call_args(fn_name, &resolved.params, args, ctx, &mut errors);
                         }
                     }
                 }

--- a/src/check/rules/unhandled.rs
+++ b/src/check/rules/unhandled.rs
@@ -122,8 +122,8 @@ impl UnhandledErrorsRule {
         let parts: Vec<&str> = call.split('.').collect();
 
         if parts.len() == 1 {
-            // Top-level function or extern fn
             let name = parts[0];
+            // Check current file
             for item in &ctx.check.file.items {
                 match item {
                     Item::Function(f) if f.name == name => {
@@ -134,6 +134,10 @@ impl UnhandledErrorsRule {
                     }
                     _ => {}
                 }
+            }
+            // Check imported functions
+            if let Some(resolved) = crate::resolve::find_imported_fn(name, ctx.check.file, ctx.check.source_dir.as_deref()) {
+                return resolved.errors.iter().map(|e| e.name.clone()).collect();
             }
         } else {
             // Dotted call: resolve the last segment as method name

--- a/src/check/walker.rs
+++ b/src/check/walker.rs
@@ -118,9 +118,9 @@ pub fn infer_type_with_registry(expr: &Expr, scope: &Scope, registry: Option<&su
 
 // ─── Walker ─────────────────────────────────────────────
 
-pub fn walk(file: &SourceFile, registry: &ContractRegistry, rules: &[Box<dyn Rule>]) -> Vec<RuleError> {
+pub fn walk(file: &SourceFile, registry: &ContractRegistry, source_dir: Option<&std::path::Path>, rules: &[Box<dyn Rule>]) -> Vec<RuleError> {
     let mut errors = Vec::new();
-    let check = CheckContext { file, registry };
+    let check = CheckContext { file, registry, source_dir: source_dir.map(|p| p.to_path_buf()) };
 
     for item in &file.items {
         let item_ctx = ItemContext { check: &check, item };

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -81,7 +81,8 @@ pub fn resolve_file_from_project(path: &Path, project: &resolve::ResolvedProject
                 })?
         }
     };
-    let errors = check::check_with_registry(&file, &project.registry);
+    let source_dir = path.parent();
+    let errors = check::check_with_registry_and_dir(&file, &project.registry, source_dir);
     if !errors.is_empty() {
         // Only read source for error logging
         let source_text = fs::read_to_string(path).unwrap_or_default();

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -2,8 +2,70 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use crate::ast::{SourceFile, ImportSource};
+use crate::ast::{SourceFile, Item, ImportSource, Param, ErrDecl, collect_returned_error_names};
 use crate::check::registry::ContractRegistry;
+
+/// Summary of a resolved function's signature -- used by checker rules to avoid
+/// duplicating the "iterate imports, load file, find function" pattern.
+#[derive(Debug, Clone)]
+pub struct ResolvedFn {
+    pub params: Vec<Param>,
+    pub returns_err: bool,
+    pub errors: Vec<ErrDecl>,
+}
+
+/// Search `file`'s imports for a function named `name`, loading .roca files
+/// relative to `source_dir`. Returns the function's signature if found.
+pub fn find_imported_fn(
+    name: &str,
+    file: &SourceFile,
+    source_dir: Option<&Path>,
+) -> Option<ResolvedFn> {
+    for item in &file.items {
+        let imp = match item {
+            Item::Import(imp) => imp,
+            _ => continue,
+        };
+        if !imp.names.iter().any(|n| n == name) {
+            continue;
+        }
+        let path = match &imp.source {
+            ImportSource::Path(p) => p,
+            _ => continue,
+        };
+        let imported = try_load_roca_file_from(path, source_dir)?;
+        for imp_item in &imported.items {
+            match imp_item {
+                Item::Function(f) if f.name == name => {
+                    // FnDef.errors is always empty for parsed functions —
+                    // error names are extracted from ReturnErr statements in the body.
+                    let errors = if f.errors.is_empty() {
+                        collect_returned_error_names(&f.body)
+                            .into_iter()
+                            .map(|name| ErrDecl { name, message: String::new() })
+                            .collect()
+                    } else {
+                        f.errors.clone()
+                    };
+                    return Some(ResolvedFn {
+                        params: f.params.clone(),
+                        returns_err: f.returns_err,
+                        errors,
+                    });
+                }
+                Item::ExternFn(f) if f.name == name => {
+                    return Some(ResolvedFn {
+                        params: f.params.clone(),
+                        returns_err: f.returns_err,
+                        errors: f.errors.clone(),
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
 
 /// Resolved project — all files parsed, combined registry built
 pub struct ResolvedProject {
@@ -13,9 +75,19 @@ pub struct ResolvedProject {
 
 /// Try to load and parse a .roca file by searching common base directories.
 pub fn try_load_roca_file(rel_path: &str) -> Option<SourceFile> {
+    try_load_roca_file_from(rel_path, None)
+}
+
+/// Try to load and parse a .roca file, optionally searching from a specific directory.
+pub fn try_load_roca_file_from(rel_path: &str, from_dir: Option<&Path>) -> Option<SourceFile> {
     let roca_path = Path::new(rel_path);
-    for base in &[".", "src"] {
-        let full_path = Path::new(base).join(roca_path);
+    let mut bases: Vec<PathBuf> = vec![PathBuf::from("."), PathBuf::from("src")];
+    if let Some(dir) = from_dir {
+        bases.insert(0, dir.to_path_buf());
+        bases.insert(1, dir.join("src"));
+    }
+    for base in &bases {
+        let full_path = base.join(roca_path);
         if let Ok(source) = std::fs::read_to_string(&full_path) {
             if let Ok(file) = crate::parse::try_parse(&source) {
                 return Some(file);

--- a/tests/verify/cross_module.rs
+++ b/tests/verify/cross_module.rs
@@ -47,10 +47,6 @@ fn cross_module_satisfies_resolved() {
             const email = Email.create(raw)
             const trimmed = email.trim()
             return trimmed
-            crash {
-                Email.create -> halt
-                email.trim -> halt
-            }
             test { self(" cam@test.com ") == "cam@test.com" }
         }
     "#).unwrap();
@@ -65,7 +61,7 @@ fn cross_module_satisfies_resolved() {
     // Check user.roca against the shared registry — should pass
     let user_source = fs::read_to_string(dir.join("user.roca")).unwrap();
     let user_file = roca::parse::parse(&user_source);
-    let errors = roca::check::check_with_registry(&user_file, &project.registry);
+    let errors = roca::check::check_with_registry_and_dir(&user_file, &project.registry, Some(&dir));
 
     let _ = fs::remove_dir_all(&dir);
 
@@ -109,11 +105,6 @@ fn cross_module_loggable_resolved() {
             const s = Secret.create(raw)
             log(s.to_log())
             return "done"
-            crash {
-                Secret.create -> halt
-                s.to_log -> halt
-                log -> skip
-            }
             test { self("password") == "done" }
         }
     "#).unwrap();
@@ -125,7 +116,7 @@ fn cross_module_loggable_resolved() {
 
     let app_source = fs::read_to_string(dir.join("app.roca")).unwrap();
     let app_file = roca::parse::parse(&app_source);
-    let errors = roca::check::check_with_registry(&app_file, &project.registry);
+    let errors = roca::check::check_with_registry_and_dir(&app_file, &project.registry, Some(&dir));
 
     let _ = fs::remove_dir_all(&dir);
 
@@ -187,4 +178,160 @@ fn cross_module_method_on_imported_type() {
 
     assert_eq!(stdout, "cam@test.com",
         "Email.trim() should work cross-module, got: {}", stdout);
+}
+
+// ─── Cross-file crash-on-safe ──────────────────────────
+
+#[test]
+fn cross_file_crash_on_safe() {
+    let dir = std::env::temp_dir().join("roca_cross_crash_safe");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    fs::write(dir.join("src").join("helper.roca"), r#"
+        /// A safe function that does not return errors
+        pub fn safe_fn(s: String) -> String {
+            return s
+            test { self("a") == "a" }
+        }
+    "#).unwrap();
+
+    fs::write(dir.join("src").join("main.roca"), r#"
+        import { safe_fn } from "./helper.roca"
+
+        /// Calls safe_fn with unnecessary crash block
+        pub fn caller() -> String {
+            const r = safe_fn("x")
+            return r
+            crash { safe_fn -> halt }
+            test { self() == "x" }
+        }
+    "#).unwrap();
+
+    let src_dir = dir.join("src");
+    let project = roca::resolve::resolve_directory(&src_dir);
+    let source = fs::read_to_string(src_dir.join("main.roca")).unwrap();
+    let file = roca::parse::parse(&source);
+    let errors = roca::check::check_with_registry_and_dir(&file, &project.registry, Some(&src_dir));
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(errors.iter().any(|e| e.code == "crash-on-safe"),
+        "expected crash-on-safe for imported non-error function, got: {:?}", errors);
+}
+
+// ─── Cross-file arg type mismatch ──────────────────────
+
+#[test]
+fn cross_file_arg_type_mismatch() {
+    let dir = std::env::temp_dir().join("roca_cross_arg_type");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    fs::write(dir.join("src").join("math.roca"), r#"
+        /// Adds two numbers
+        pub fn add(a: Number, b: Number) -> Number {
+            return a + b
+            test { self(1, 2) == 3 }
+        }
+    "#).unwrap();
+
+    fs::write(dir.join("src").join("main.roca"), r#"
+        import { add } from "./math.roca"
+
+        /// Calls add with wrong types
+        pub fn bad() -> Number {
+            return add("a", "b")
+            test { self() == 0 }
+        }
+    "#).unwrap();
+
+    let src_dir = dir.join("src");
+    let project = roca::resolve::resolve_directory(&src_dir);
+    let source = fs::read_to_string(src_dir.join("main.roca")).unwrap();
+    let file = roca::parse::parse(&source);
+    let errors = roca::check::check_with_registry_and_dir(&file, &project.registry, Some(&src_dir));
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(errors.iter().any(|e| e.code == "arg-type-mismatch"),
+        "expected arg-type-mismatch for imported function, got: {:?}", errors);
+}
+
+// ─── Cross-file valid call passes ──────────────────────
+
+#[test]
+fn cross_file_valid_call_passes() {
+    let dir = std::env::temp_dir().join("roca_cross_valid");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    fs::write(dir.join("src").join("helper.roca"), r#"
+        /// Greets by name
+        pub fn greet(name: String) -> String {
+            return "Hello " + name
+            test { self("cam") == "Hello cam" }
+        }
+    "#).unwrap();
+
+    fs::write(dir.join("src").join("main.roca"), r#"
+        import { greet } from "./helper.roca"
+
+        /// Uses greet correctly
+        pub fn welcome(name: String) -> String {
+            return greet(name)
+            test { self("cam") == "Hello cam" }
+        }
+    "#).unwrap();
+
+    let src_dir = dir.join("src");
+    let project = roca::resolve::resolve_directory(&src_dir);
+    let source = fs::read_to_string(src_dir.join("main.roca")).unwrap();
+    let file = roca::parse::parse(&source);
+    let errors = roca::check::check_with_registry_and_dir(&file, &project.registry, Some(&src_dir));
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(errors.is_empty(),
+        "valid cross-file call should pass, got: {:?}", errors);
+}
+
+// ─── Cross-file unhandled error propagation ───────────
+
+#[test]
+fn cross_file_unhandled_error() {
+    let dir = std::env::temp_dir().join("roca_cross_unhandled");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    fs::write(dir.join("src").join("db.roca"), r#"
+        /// Fetches a record
+        pub fn fetch(id: String) -> String, err {
+            err not_found = "not found"
+            if id == "" { return err.not_found }
+            return "data"
+            test { self("1") == "data" self("") is err.not_found }
+        }
+    "#).unwrap();
+
+    // Caller halts on fetch but does NOT declare its own errors —
+    // the unhandled-error rule should fire.
+    fs::write(dir.join("src").join("main.roca"), r#"
+        import { fetch } from "./db.roca"
+
+        /// Uses fetch but does not declare errors
+        pub fn get_data(id: String) -> String {
+            const r = fetch(id)
+            return r
+            crash { fetch -> halt }
+            test { self("1") == "data" }
+        }
+    "#).unwrap();
+
+    let src_dir = dir.join("src");
+    let project = roca::resolve::resolve_directory(&src_dir);
+    let source = fs::read_to_string(src_dir.join("main.roca")).unwrap();
+    let file = roca::parse::parse(&source);
+    let errors = roca::check::check_with_registry_and_dir(&file, &project.registry, Some(&src_dir));
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(errors.iter().any(|e| e.code == "unhandled-error"),
+        "expected unhandled-error for imported function with halt, got: {:?}", errors);
 }


### PR DESCRIPTION
## Summary
- Thread `source_dir` through `CheckContext` so import resolution works from any directory
- `try_load_roca_file_from()` searches relative to the source file's location
- Fixes `crash-on-safe`, `arg-type-mismatch`, and `unhandled-error` for imported functions

## Test plan
- [x] 3 new cross-file tests (crash-on-safe, arg-type-mismatch, valid-call)
- [x] Worker example verified: `roca check` catches invalid crash entries cross-file
- [x] All 781 tests pass
- [x] Zero warnings

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Cross-module function validation now supports imported functions with comprehensive type checking, error handling verification and crash block detection across file boundaries.
- Implemented directory-aware import path resolution enabling correct relative file lookups based on source file location for multi-file projects.

## Refactor
- Removed unreachable code block from example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->