### PR TITLE
feat(native): implement Crypto, Url, Encoding, JSON, Http stdlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +53,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -104,10 +116,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "compact_str"
@@ -434,6 +462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,13 +572,40 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -593,6 +654,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +699,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -728,6 +882,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +918,8 @@ version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -796,6 +968,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-types"
@@ -1274,6 +1452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1480,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,9 +1545,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1343,9 +1620,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rocalang"
 version = "0.3.0"
 dependencies = [
+ "base64",
  "cranelift-codegen",
  "cranelift-frontend",
  "cranelift-jit",
@@ -1358,6 +1688,7 @@ dependencies = [
  "oxc_codegen",
  "oxc_parser",
  "oxc_span",
+ "reqwest",
  "serde_json",
  "sha2",
  "tokio",
@@ -1371,6 +1702,41 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -1463,6 +1829,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1850,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1530,6 +1914,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1928,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1599,6 +1998,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +2038,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1654,6 +2078,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,7 +2134,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-lsp-macros",
  "tracing",
 ]
@@ -1731,6 +2188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +2236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,7 +2266,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1807,6 +2276,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1843,6 +2321,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1931,6 +2419,35 @@ dependencies = [
  "libc",
  "wasmtime-internal-core",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2139,6 +2656,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2695,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ cranelift-module = "0.130"
 cranelift-jit = "0.130"
 cranelift-native = "0.130"
 cranelift-object = "0.130"
+base64 = "0.22"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/src/native/runtime/mod.rs
+++ b/src/native/runtime/mod.rs
@@ -156,6 +156,55 @@ runtime_funcs! {
     (fs_exists,         "roca_fs_exists",         roca_fs_exists,         [types::I64],                                [types::I8]),
     (fs_read_dir,       "roca_fs_read_dir",       roca_fs_read_dir,       [types::I64],                                [types::I64, types::I8]),
 
+    // Crypto
+    (crypto_random_uuid, "roca_crypto_random_uuid", roca_crypto_random_uuid, [],                                        [types::I64]),
+    (crypto_sha256,     "roca_crypto_sha256",     roca_crypto_sha256,     [types::I64],                                [types::I64]),
+    (crypto_sha512,     "roca_crypto_sha512",     roca_crypto_sha512,     [types::I64],                                [types::I64]),
+
+    // Url
+    (url_parse,         "roca_url_parse",         roca_url_parse,         [types::I64],                                [types::I64, types::I8]),
+    (url_is_valid,      "roca_url_is_valid",      roca_url_is_valid,      [types::I64],                                [types::I8]),
+    (url_hostname,      "roca_url_hostname",      roca_url_hostname,      [types::I64],                                [types::I64]),
+    (url_protocol,      "roca_url_protocol",      roca_url_protocol,      [types::I64],                                [types::I64]),
+    (url_pathname,      "roca_url_pathname",      roca_url_pathname,      [types::I64],                                [types::I64]),
+    (url_search,        "roca_url_search",        roca_url_search,        [types::I64],                                [types::I64]),
+    (url_hash,          "roca_url_hash",          roca_url_hash,          [types::I64],                                [types::I64]),
+    (url_host,          "roca_url_host",          roca_url_host,          [types::I64],                                [types::I64]),
+    (url_port,          "roca_url_port",          roca_url_port,          [types::I64],                                [types::I64]),
+    (url_origin,        "roca_url_origin",        roca_url_origin,        [types::I64],                                [types::I64]),
+    (url_href,          "roca_url_href",          roca_url_href,          [types::I64],                                [types::I64]),
+    (url_to_string,     "roca_url_to_string",     roca_url_to_string,     [types::I64],                                [types::I64]),
+    (url_get_param,     "roca_url_get_param",     roca_url_get_param,     [types::I64, types::I64],                    [types::I64]),
+    (url_has_param,     "roca_url_has_param",     roca_url_has_param,     [types::I64, types::I64],                    [types::I8]),
+
+    // Encoding
+    (encoding_btoa,     "roca_encoding_btoa",     roca_encoding_btoa,     [types::I64],                                [types::I64, types::I8]),
+    (encoding_atob,     "roca_encoding_atob",     roca_encoding_atob,     [types::I64],                                [types::I64, types::I8]),
+    (encoding_encode,   "roca_encoding_encode",   roca_encoding_encode,   [types::I64],                                [types::I64]),
+    (encoding_decode,   "roca_encoding_decode",   roca_encoding_decode,   [types::I64],                                [types::I64, types::I8]),
+
+    // JSON
+    (json_parse,        "roca_json_parse",        roca_json_parse,        [types::I64],                                [types::I64, types::I8]),
+    (json_stringify,    "roca_json_stringify",     roca_json_stringify,    [types::I64],                                [types::I64]),
+    (json_get,          "roca_json_get",          roca_json_get,          [types::I64, types::I64],                    [types::I64]),
+    (json_get_string,   "roca_json_get_string",   roca_json_get_string,   [types::I64, types::I64],                    [types::I64]),
+    (json_get_number,   "roca_json_get_number",   roca_json_get_number,   [types::I64, types::I64],                    [types::F64]),
+    (json_get_bool,     "roca_json_get_bool",     roca_json_get_bool,     [types::I64, types::I64],                    [types::I8]),
+    (json_get_array,    "roca_json_get_array",    roca_json_get_array,    [types::I64, types::I64],                    [types::I64]),
+    (json_to_string,    "roca_json_to_string",    roca_json_to_string,    [types::I64],                                [types::I64]),
+
+    // Http
+    (http_get,          "roca_http_get",          roca_http_get,          [types::I64],                                [types::I64, types::I8]),
+    (http_post,         "roca_http_post",         roca_http_post,         [types::I64, types::I64],                    [types::I64, types::I8]),
+    (http_put,          "roca_http_put",          roca_http_put,          [types::I64, types::I64],                    [types::I64, types::I8]),
+    (http_patch,        "roca_http_patch",        roca_http_patch,        [types::I64, types::I64],                    [types::I64, types::I8]),
+    (http_delete,       "roca_http_delete",       roca_http_delete,       [types::I64],                                [types::I64, types::I8]),
+    (http_status,       "roca_http_status",       roca_http_status,       [types::I64],                                [types::F64]),
+    (http_ok,           "roca_http_ok",           roca_http_ok,           [types::I64],                                [types::I8]),
+    (http_text,         "roca_http_text",         roca_http_text,         [types::I64],                                [types::I64, types::I8]),
+    (http_json,         "roca_http_json",         roca_http_json,         [types::I64],                                [types::I64, types::I8]),
+    (http_header,       "roca_http_header",       roca_http_header,       [types::I64, types::I64],                    [types::I64]),
+
     // Memory management
     (string_new,        "roca_string_new",        roca_string_new,        [types::I64],                                [types::I64]),
     (rc_alloc,          "roca_rc_alloc",          roca_rc_alloc,          [types::I64],                                [types::I64]),

--- a/src/native/runtime/stdlib.rs
+++ b/src/native/runtime/stdlib.rs
@@ -400,3 +400,302 @@ pub extern "C" fn roca_fs_read_dir(path: i64) -> (i64, u8) {
         }
     }
 }
+
+// ─── Crypto ─────────────────────────────────────────
+
+pub extern "C" fn roca_crypto_random_uuid() -> i64 {
+    alloc_str(&uuid::Uuid::new_v4().to_string())
+}
+
+pub extern "C" fn roca_crypto_sha256(data: i64) -> i64 {
+    use sha2::Digest;
+    let input = read_cstr(data);
+    let hash = sha2::Sha256::digest(input.as_bytes());
+    let hex: String = hash.iter().map(|b| format!("{:02x}", b)).collect(); alloc_str(&hex)
+}
+
+pub extern "C" fn roca_crypto_sha512(data: i64) -> i64 {
+    use sha2::Digest;
+    let input = read_cstr(data);
+    let hash = sha2::Sha512::digest(input.as_bytes());
+    let hex: String = hash.iter().map(|b| format!("{:02x}", b)).collect(); alloc_str(&hex)
+}
+
+// ─── Url ────────────────────────────────────────────
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_url_parse(raw: i64) -> (i64, u8) {
+    match url::Url::parse(read_cstr(raw)) {
+        Ok(parsed) => (Box::into_raw(Box::new(parsed)) as i64, 0),
+        Err(_) => (0, 1),
+    }
+}
+
+pub extern "C" fn roca_url_is_valid(raw: i64) -> u8 {
+    if url::Url::parse(read_cstr(raw)).is_ok() { 1 } else { 0 }
+}
+
+fn with_url<F: FnOnce(&url::Url) -> i64>(ptr: i64, f: F) -> i64 {
+    if ptr == 0 { return alloc_str(""); }
+    let url = unsafe { &*(ptr as *const url::Url) };
+    f(url)
+}
+
+pub extern "C" fn roca_url_hostname(ptr: i64) -> i64 {
+    with_url(ptr, |u| alloc_str(u.host_str().unwrap_or("")))
+}
+
+pub extern "C" fn roca_url_protocol(ptr: i64) -> i64 {
+    with_url(ptr, |u| alloc_str(&format!("{}:", u.scheme())))
+}
+
+pub extern "C" fn roca_url_pathname(ptr: i64) -> i64 {
+    with_url(ptr, |u| alloc_str(u.path()))
+}
+
+pub extern "C" fn roca_url_search(ptr: i64) -> i64 {
+    with_url(ptr, |u| alloc_str(&u.query().map_or(String::new(), |q| format!("?{}", q))))
+}
+
+pub extern "C" fn roca_url_hash(ptr: i64) -> i64 {
+    with_url(ptr, |u| alloc_str(&u.fragment().map_or(String::new(), |f| format!("#{}", f))))
+}
+
+pub extern "C" fn roca_url_host(ptr: i64) -> i64 {
+    with_url(ptr, |u| {
+        let host = u.host_str().unwrap_or("");
+        match u.port() {
+            Some(p) => alloc_str(&format!("{}:{}", host, p)),
+            None => alloc_str(host),
+        }
+    })
+}
+
+pub extern "C" fn roca_url_port(ptr: i64) -> i64 {
+    with_url(ptr, |u| alloc_str(&u.port().map_or(String::new(), |p| p.to_string())))
+}
+
+pub extern "C" fn roca_url_origin(ptr: i64) -> i64 {
+    with_url(ptr, |u| alloc_str(&u.origin().ascii_serialization()))
+}
+
+pub extern "C" fn roca_url_href(ptr: i64) -> i64 {
+    with_url(ptr, |u| alloc_str(u.as_str()))
+}
+
+pub extern "C" fn roca_url_to_string(ptr: i64) -> i64 {
+    roca_url_href(ptr)
+}
+
+pub extern "C" fn roca_url_get_param(ptr: i64, name: i64) -> i64 {
+    if ptr == 0 { return 0; }
+    let url = unsafe { &*(ptr as *const url::Url) };
+    match url.query_pairs().find(|(k, _)| k == read_cstr(name)) {
+        Some((_, v)) => alloc_str(&v),
+        None => 0,
+    }
+}
+
+pub extern "C" fn roca_url_has_param(ptr: i64, name: i64) -> u8 {
+    if ptr == 0 { return 0; }
+    let url = unsafe { &*(ptr as *const url::Url) };
+    if url.query_pairs().any(|(k, _)| k == read_cstr(name)) { 1 } else { 0 }
+}
+
+// ─── Encoding ───────────────────────────────────────
+
+use base64::Engine;
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_encoding_btoa(input: i64) -> (i64, u8) {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(read_cstr(input).as_bytes());
+    (alloc_str(&encoded), 0)
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_encoding_atob(input: i64) -> (i64, u8) {
+    match base64::engine::general_purpose::STANDARD.decode(read_cstr(input).as_bytes()) {
+        Ok(bytes) => match String::from_utf8(bytes) {
+            Ok(decoded) => (alloc_str(&decoded), 0),
+            Err(_) => (0, 1),
+        },
+        Err(_) => (0, 1),
+    }
+}
+
+pub extern "C" fn roca_encoding_encode(input: i64) -> i64 {
+    input // strings are already UTF-8 in native
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_encoding_decode(bytes: i64) -> (i64, u8) {
+    if bytes == 0 { return (0, 1); }
+    (bytes, 0)
+}
+
+// ─── JSON ───────────────────────────────────────────
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_json_parse(text: i64) -> (i64, u8) {
+    match serde_json::from_str::<serde_json::Value>(read_cstr(text)) {
+        Ok(value) => (Box::into_raw(Box::new(value)) as i64, 0),
+        Err(_) => (0, 1),
+    }
+}
+
+pub extern "C" fn roca_json_stringify(json: i64) -> i64 {
+    if json == 0 { return alloc_str("null"); }
+    let value = unsafe { &*(json as *const serde_json::Value) };
+    alloc_str(&value.to_string())
+}
+
+pub extern "C" fn roca_json_get(json: i64, key: i64) -> i64 {
+    if json == 0 { return 0; }
+    let value = unsafe { &*(json as *const serde_json::Value) };
+    match value.get(read_cstr(key)) {
+        Some(v) => Box::into_raw(Box::new(v.clone())) as i64,
+        None => 0,
+    }
+}
+
+pub extern "C" fn roca_json_get_string(json: i64, key: i64) -> i64 {
+    if json == 0 { return 0; }
+    let value = unsafe { &*(json as *const serde_json::Value) };
+    match value.get(read_cstr(key)).and_then(|v| v.as_str()) {
+        Some(s) => alloc_str(s),
+        None => 0,
+    }
+}
+
+pub extern "C" fn roca_json_get_number(json: i64, key: i64) -> f64 {
+    if json == 0 { return f64::NAN; }
+    let value = unsafe { &*(json as *const serde_json::Value) };
+    value.get(read_cstr(key)).and_then(|v| v.as_f64()).unwrap_or(f64::NAN)
+}
+
+pub extern "C" fn roca_json_get_bool(json: i64, key: i64) -> u8 {
+    if json == 0 { return 0; }
+    let value = unsafe { &*(json as *const serde_json::Value) };
+    match value.get(read_cstr(key)).and_then(|v| v.as_bool()) {
+        Some(true) => 1,
+        _ => 0,
+    }
+}
+
+pub extern "C" fn roca_json_get_array(json: i64, key: i64) -> i64 {
+    if json == 0 { return 0; }
+    let value = unsafe { &*(json as *const serde_json::Value) };
+    match value.get(read_cstr(key)).and_then(|v| v.as_array()) {
+        Some(arr) => {
+            let result = roca_array_new();
+            for item in arr {
+                let ptr = Box::into_raw(Box::new(item.clone())) as i64;
+                roca_array_push_str(result, ptr);
+            }
+            result
+        }
+        None => 0,
+    }
+}
+
+pub extern "C" fn roca_json_to_string(json: i64) -> i64 {
+    roca_json_stringify(json)
+}
+
+// ─── Http ───────────────────────────────────────────
+
+struct HttpResponse {
+    status: u16,
+    headers: std::collections::HashMap<String, String>,
+    body: String,
+}
+
+fn http_request(method: &str, url_str: &str, body: Option<&str>) -> Result<HttpResponse, String> {
+    tokio_rt().block_on(async {
+        let client = reqwest::Client::new();
+        let mut req = match method {
+            "GET" => client.get(url_str),
+            "POST" => client.post(url_str),
+            "PUT" => client.put(url_str),
+            "PATCH" => client.patch(url_str),
+            "DELETE" => client.delete(url_str),
+            _ => return Err("unsupported method".into()),
+        };
+        if let Some(b) = body { req = req.body(b.to_string()); }
+        match req.send().await {
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                let headers = resp.headers().iter()
+                    .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+                    .collect();
+                let body = resp.text().await.unwrap_or_default();
+                Ok(HttpResponse { status, headers, body })
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    })
+}
+
+fn box_response(result: Result<HttpResponse, String>) -> (i64, u8) {
+    match result {
+        Ok(resp) => (Box::into_raw(Box::new(resp)) as i64, 0),
+        Err(_) => (0, 1),
+    }
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_http_get(url: i64) -> (i64, u8) {
+    box_response(http_request("GET", read_cstr(url), None))
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_http_post(url: i64, body: i64) -> (i64, u8) {
+    box_response(http_request("POST", read_cstr(url), Some(read_cstr(body))))
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_http_put(url: i64, body: i64) -> (i64, u8) {
+    box_response(http_request("PUT", read_cstr(url), Some(read_cstr(body))))
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_http_patch(url: i64, body: i64) -> (i64, u8) {
+    box_response(http_request("PATCH", read_cstr(url), Some(read_cstr(body))))
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_http_delete(url: i64) -> (i64, u8) {
+    box_response(http_request("DELETE", read_cstr(url), None))
+}
+
+pub extern "C" fn roca_http_status(resp: i64) -> f64 {
+    if resp == 0 { return 0.0; }
+    unsafe { &*(resp as *const HttpResponse) }.status as f64
+}
+
+pub extern "C" fn roca_http_ok(resp: i64) -> u8 {
+    if resp == 0 { return 0; }
+    let s = unsafe { &*(resp as *const HttpResponse) }.status;
+    if (200..300).contains(&s) { 1 } else { 0 }
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_http_text(resp: i64) -> (i64, u8) {
+    if resp == 0 { return (0, 1); }
+    (alloc_str(&unsafe { &*(resp as *const HttpResponse) }.body), 0)
+}
+
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn roca_http_json(resp: i64) -> (i64, u8) {
+    if resp == 0 { return (0, 1); }
+    roca_json_parse(alloc_str(&unsafe { &*(resp as *const HttpResponse) }.body))
+}
+
+pub extern "C" fn roca_http_header(resp: i64, name: i64) -> i64 {
+    if resp == 0 { return 0; }
+    let r = unsafe { &*(resp as *const HttpResponse) };
+    match r.headers.get(&read_cstr(name).to_lowercase()) {
+        Some(v) => alloc_str(v),
+        None => 0,
+    }
+}

--- a/src/native/tests_stdlib_ext.rs
+++ b/src/native/tests_stdlib_ext.rs
@@ -480,3 +480,217 @@ fn param_constraint_multiple_params() {
     f(25.0, 2000.0);
     assert!(runtime::constraint_violated(), "score 2000 > max 1000");
 }
+
+// ─── Crypto ─────────────────────────────────────────
+
+#[test]
+fn crypto_random_uuid_length() {
+    let uuid = runtime::roca_crypto_random_uuid();
+    let s = unsafe { std::ffi::CStr::from_ptr(uuid as *const i8) }.to_str().unwrap();
+    assert_eq!(s.len(), 36, "UUID should be 36 chars: {}", s);
+}
+
+#[test]
+fn crypto_uuid_unique() {
+    let a = runtime::roca_crypto_random_uuid();
+    let b = runtime::roca_crypto_random_uuid();
+    let a_str = unsafe { std::ffi::CStr::from_ptr(a as *const i8) }.to_str().unwrap();
+    let b_str = unsafe { std::ffi::CStr::from_ptr(b as *const i8) }.to_str().unwrap();
+    assert_ne!(a_str, b_str, "two UUIDs should be different");
+}
+
+#[test]
+fn crypto_sha256_known_hash() {
+    let input = runtime::alloc_str("");
+    let hash = runtime::roca_crypto_sha256(input);
+    let s = unsafe { std::ffi::CStr::from_ptr(hash as *const i8) }.to_str().unwrap();
+    assert!(s.starts_with("e3b0c44"), "SHA-256 of empty string: {}", s);
+    assert_eq!(s.len(), 64, "SHA-256 hex should be 64 chars");
+}
+
+#[test]
+fn crypto_sha512_known_hash() {
+    let input = runtime::alloc_str("");
+    let hash = runtime::roca_crypto_sha512(input);
+    let s = unsafe { std::ffi::CStr::from_ptr(hash as *const i8) }.to_str().unwrap();
+    assert!(s.starts_with("cf83e1"), "SHA-512 of empty string: {}", s);
+    assert_eq!(s.len(), 128, "SHA-512 hex should be 128 chars");
+}
+
+// ─── Url ────────────────────────────────────────────
+
+#[test]
+fn url_parse_valid() {
+    let raw = runtime::alloc_str("https://example.com:8080/path?q=1#frag");
+    let (ptr, err) = runtime::roca_url_parse(raw);
+    assert_eq!(err, 0, "parse should succeed");
+    assert_ne!(ptr, 0);
+
+    let hostname = runtime::roca_url_hostname(ptr);
+    let h = unsafe { std::ffi::CStr::from_ptr(hostname as *const i8) }.to_str().unwrap();
+    assert_eq!(h, "example.com");
+
+    let protocol = runtime::roca_url_protocol(ptr);
+    let p = unsafe { std::ffi::CStr::from_ptr(protocol as *const i8) }.to_str().unwrap();
+    assert_eq!(p, "https:");
+
+    let pathname = runtime::roca_url_pathname(ptr);
+    let pa = unsafe { std::ffi::CStr::from_ptr(pathname as *const i8) }.to_str().unwrap();
+    assert_eq!(pa, "/path");
+
+    let search = runtime::roca_url_search(ptr);
+    let s = unsafe { std::ffi::CStr::from_ptr(search as *const i8) }.to_str().unwrap();
+    assert_eq!(s, "?q=1");
+
+    let hash = runtime::roca_url_hash(ptr);
+    let f = unsafe { std::ffi::CStr::from_ptr(hash as *const i8) }.to_str().unwrap();
+    assert_eq!(f, "#frag");
+}
+
+#[test]
+fn url_parse_invalid() {
+    let raw = runtime::alloc_str("not a url");
+    let (_, err) = runtime::roca_url_parse(raw);
+    assert_ne!(err, 0, "parse should fail for invalid URL");
+}
+
+#[test]
+fn url_is_valid_check() {
+    let valid = runtime::alloc_str("https://example.com");
+    assert_eq!(runtime::roca_url_is_valid(valid), 1);
+
+    let invalid = runtime::alloc_str("nope");
+    assert_eq!(runtime::roca_url_is_valid(invalid), 0);
+}
+
+#[test]
+fn url_get_param_works() {
+    let raw = runtime::alloc_str("https://x.com?foo=bar&baz=42");
+    let (ptr, _) = runtime::roca_url_parse(raw);
+    let key = runtime::alloc_str("foo");
+    let val = runtime::roca_url_get_param(ptr, key);
+    let v = unsafe { std::ffi::CStr::from_ptr(val as *const i8) }.to_str().unwrap();
+    assert_eq!(v, "bar");
+
+    let missing = runtime::alloc_str("nope");
+    assert_eq!(runtime::roca_url_get_param(ptr, missing), 0);
+}
+
+#[test]
+fn url_has_param_works() {
+    let raw = runtime::alloc_str("https://x.com?foo=bar");
+    let (ptr, _) = runtime::roca_url_parse(raw);
+    let key = runtime::alloc_str("foo");
+    assert_eq!(runtime::roca_url_has_param(ptr, key), 1);
+    let missing = runtime::alloc_str("nope");
+    assert_eq!(runtime::roca_url_has_param(ptr, missing), 0);
+}
+
+// ─── Encoding ───────────────────────────────────────
+
+#[test]
+fn encoding_btoa_hello() {
+    let input = runtime::alloc_str("hello");
+    let (result, err) = runtime::roca_encoding_btoa(input);
+    assert_eq!(err, 0);
+    let s = unsafe { std::ffi::CStr::from_ptr(result as *const i8) }.to_str().unwrap();
+    assert_eq!(s, "aGVsbG8=");
+}
+
+#[test]
+fn encoding_atob_hello() {
+    let input = runtime::alloc_str("aGVsbG8=");
+    let (result, err) = runtime::roca_encoding_atob(input);
+    assert_eq!(err, 0);
+    let s = unsafe { std::ffi::CStr::from_ptr(result as *const i8) }.to_str().unwrap();
+    assert_eq!(s, "hello");
+}
+
+#[test]
+fn encoding_roundtrip() {
+    let input = runtime::alloc_str("test data 123");
+    let (encoded, _) = runtime::roca_encoding_btoa(input);
+    let (decoded, _) = runtime::roca_encoding_atob(encoded);
+    let s = unsafe { std::ffi::CStr::from_ptr(decoded as *const i8) }.to_str().unwrap();
+    assert_eq!(s, "test data 123");
+}
+
+#[test]
+fn encoding_atob_invalid() {
+    let input = runtime::alloc_str("!!!invalid!!!");
+    let (_, err) = runtime::roca_encoding_atob(input);
+    assert_ne!(err, 0, "invalid base64 should return error");
+}
+
+// ─── JSON ───────────────────────────────────────────
+
+#[test]
+fn json_parse_valid() {
+    let text = runtime::alloc_str(r#"{"name":"cam","age":30,"active":true}"#);
+    let (ptr, err) = runtime::roca_json_parse(text);
+    assert_eq!(err, 0);
+    assert_ne!(ptr, 0);
+
+    let name_key = runtime::alloc_str("name");
+    let name = runtime::roca_json_get_string(ptr, name_key);
+    let n = unsafe { std::ffi::CStr::from_ptr(name as *const i8) }.to_str().unwrap();
+    assert_eq!(n, "cam");
+
+    let age_key = runtime::alloc_str("age");
+    let age = runtime::roca_json_get_number(ptr, age_key);
+    assert_eq!(age, 30.0);
+
+    let active_key = runtime::alloc_str("active");
+    let active = runtime::roca_json_get_bool(ptr, active_key);
+    assert_eq!(active, 1);
+}
+
+#[test]
+fn json_parse_invalid() {
+    let text = runtime::alloc_str("not json");
+    let (_, err) = runtime::roca_json_parse(text);
+    assert_ne!(err, 0);
+}
+
+#[test]
+fn json_stringify_roundtrip() {
+    let text = runtime::alloc_str(r#"{"a":1}"#);
+    let (ptr, _) = runtime::roca_json_parse(text);
+    let output = runtime::roca_json_stringify(ptr);
+    let s = unsafe { std::ffi::CStr::from_ptr(output as *const i8) }.to_str().unwrap();
+    assert!(s.contains("\"a\""), "should contain key: {}", s);
+    assert!(s.contains("1"), "should contain value: {}", s);
+}
+
+#[test]
+fn json_nested_get() {
+    let text = runtime::alloc_str(r#"{"user":{"name":"cam"}}"#);
+    let (ptr, _) = runtime::roca_json_parse(text);
+    let user_key = runtime::alloc_str("user");
+    let user = runtime::roca_json_get(ptr, user_key);
+    assert_ne!(user, 0);
+    let name_key = runtime::alloc_str("name");
+    let name = runtime::roca_json_get_string(user, name_key);
+    let n = unsafe { std::ffi::CStr::from_ptr(name as *const i8) }.to_str().unwrap();
+    assert_eq!(n, "cam");
+}
+
+// ─── Http ───────────────────────────────────────────
+
+#[test]
+#[ignore] // requires network
+fn http_get_real() {
+    let url = runtime::alloc_str("https://httpbin.org/get");
+    let (resp, err) = runtime::roca_http_get(url);
+    assert_eq!(err, 0, "GET should succeed");
+    let status = runtime::roca_http_status(resp);
+    assert_eq!(status, 200.0);
+    assert_eq!(runtime::roca_http_ok(resp), 1);
+}
+
+#[test]
+fn http_get_bad_url() {
+    let url = runtime::alloc_str("http://localhost:1");
+    let (_, err) = runtime::roca_http_get(url);
+    assert_ne!(err, 0, "bad URL should return error");
+}


### PR DESCRIPTION
## Summary

Native Cranelift JIT implementations for all 5 missing stdlib contracts. Code using these contracts can now compile via `roca build` without `--emit-only`.

| Contract | Methods | Crate |
|----------|---------|-------|
| Crypto (3) | randomUUID, sha256, sha512 | uuid, sha2 |
| Url (14) | parse, isValid, hostname, protocol, pathname, search, hash, host, port, origin, href, toString, getParam, hasParam | url |
| Encoding (4) | btoa, atob, encode, decode | base64 |
| JSON (8) | parse, stringify, get, getString, getNumber, getBool, getArray, toString | serde_json |
| Http (10) | get, post, put, patch, delete, status, ok, text, json, header | reqwest + tokio |

29 new runtime functions, 18 new native tests.

Closes #42

## Test plan
- [x] `cargo test` — 981 passed, 0 failed, 2 ignored (network test)
- [x] `bun test` — 250 passed